### PR TITLE
Change all the links in Markdown files to relative paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,22 +6,22 @@
 2. Create a new folder, name it with your GitHub username (if it does not exist yet)
 3. Place your scripts on your newly-created folder.
 4. Name the scripts based on functionality or purpose.
-   
+
    Use [snake case](https://en.wikipedia.org/wiki/Snake_case).
-   
+
    E.g. `list_newtork_interface.bash`, `create_new_file.bash`, etc.
 
-5. Add your script under [README.md's Table of Contents section](https://github.com/raymelon/scripting-recipes/tree/main#table-of-contents) (based on the script language).
-   
+5. Add your script under [README.md's Table of Contents section](#table-of-contents) (based on the script language).
+
    Use bullet outline.
-   
+
    Use the filename (with the extension).
 
    Follow the markdown format below:
-    
-    ```
-    - [test_bash.bash](https://github.com/raymelon/scripting-recipes/blob/main/raymelon/test_bash.bash)
-    ```
+
+   ```
+   - [test_bash.bash](raymelon/test_bash.bash)
+   ```
 
 6. Open a Pull Request
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # Scripting Recipes
+
 **Community collection of script recipes (Bash, PowerShell, Perl, etc.)**
 
-**Feel free to contribute your script recipes!** To do so, see [CONTRIBUTING.md](https://github.com/raymelon/scripting-recipes/blob/main/CONTRIBUTING.md).
+**Feel free to contribute your script recipes!** To do so, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Finding a script?
 
-#### See [Table of Contents](https://github.com/raymelon/scripting-recipes/tree/main#table-of-contents)
+#### See [Table of Contents](#table-of-contents)
 
 ## Contribute your favorite script recipe
 
 ### This repository is participating in [Hacktoberfest 2023](https://hacktoberfest.com/participation/#contributors)
 
-To do so, see [CONTRIBUTING.md](https://github.com/raymelon/scripting-recipes/blob/main/CONTRIBUTING.md).
+To do so, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Have Questions?
 
@@ -27,23 +28,24 @@ To do so, see [CONTRIBUTING.md](https://github.com/raymelon/scripting-recipes/bl
 
 ### Bash
 
-- [test_bash.bash](https://github.com/raymelon/scripting-recipes/blob/main/raymelon/test_bash.bash)
-- [Directory_listing_script](https://github.com/PreciousEddy/scripting-recipes/blob/main/PreciousEddy/Directory_listing_script.bash)
-- [Disk_Usage_script](https://github.com/PreciousEddy/scripting-recipes/blob/main/PreciousEddy/Disk_Usage_script.bash)
-- [Process_Check_Script](https://github.com/PreciousEddy/scripting-recipes/blob/main/PreciousEddy/Process_Check_Script.bash)
-- [automated_database_backup_script](https://github.com/PreciousEddy/scripting-recipes/blob/main/PreciousEddy/automated_database_backup_script.bash)
-- [backup_Script_with_timestamped-files](https://github.com/PreciousEddy/scripting-recipes/blob/main/PreciousEddy/backup_Script_with_timestamped-files.bash)
-- [file_backup_script](https://github.com/PreciousEddy/scripting-recipes/blob/main/PreciousEddy/file_backup_script.bash)
-- [user_account_management_script](https://github.com/PreciousEddy/scripting-recipes/blob/main/PreciousEddy/user_account_management_script.bash)
+- [test_bash.bash](raymelon/test_bash.bash)
+- [Directory_listing_script](PreciousEddy/Directory_listing_script.bash)
+- [Disk_Usage_script](PreciousEddy/Disk_Usage_script.bash)
+- [Process_Check_Script](PreciousEddy/Process_Check_Script.bash)
+- [automated_database_backup_script](PreciousEddy/automated_database_backup_script.bash)
+- [backup_Script_with_timestamped-files](PreciousEddy/backup_Script_with_timestamped-files.bash)
+- [file_backup_script](PreciousEddy/file_backup_script.bash)
+- [user_account_management_script](PreciousEddy/user_account_management_script.bash)
 
 ### Perl
-- [Service_Status_Checker.pl](https://github.com/PreciousEddy/scripting-recipes/blob/main/PreciousEddy/Perl/Service_Status_Checker.pl)
-- [System_Information_Script.pl](https://github.com/PreciousEddy/scripting-recipes/blob/main/PreciousEddy/Perl/System_Information_Script.pl)
-- [user_Disk_Usage_Checker.pl](https://github.com/PreciousEddy/scripting-recipes/blob/main/PreciousEddy/Perl/user_Disk_Usage_Checker.pl)
-- [web_server_Log_Analyzer.pl](https://github.com/PreciousEddy/scripting-recipes/blob/main/PreciousEddy/Perl/web_server_Log_Analyzer.pl)
+
+- [Service_Status_Checker.pl](PreciousEddy/Perl/Service_Status_Checker.pl)
+- [System_Information_Script.pl](PreciousEddy/Perl/System_Information_Script.pl)
+- [user_Disk_Usage_Checker.pl](PreciousEddy/Perl/user_Disk_Usage_Checker.pl)
+- [web_server_Log_Analyzer.pl](PreciousEddy/Perl/web_server_Log_Analyzer.pl)
+
 ### Python
 
 ### Batch
 
 ### PowerShell
-

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ To do so, see [CONTRIBUTING.md](CONTRIBUTING.md).
 ### Bash
 
 - [test_bash.bash](raymelon/test_bash.bash)
-- [Directory_listing_script](PreciousEddy/Directory_listing_script.bash)
-- [Disk_Usage_script](PreciousEddy/Disk_Usage_script.bash)
-- [Process_Check_Script](PreciousEddy/Process_Check_Script.bash)
-- [automated_database_backup_script](PreciousEddy/automated_database_backup_script.bash)
-- [backup_Script_with_timestamped-files](PreciousEddy/backup_Script_with_timestamped-files.bash)
-- [file_backup_script](PreciousEddy/file_backup_script.bash)
-- [user_account_management_script](PreciousEddy/user_account_management_script.bash)
+- [Directory_listing_script.bash](PreciousEddy/Directory_listing_script.bash)
+- [Disk_Usage_script.bash](PreciousEddy/Disk_Usage_script.bash)
+- [Process_Check_Script.bash](PreciousEddy/Process_Check_Script.bash)
+- [automated_database_backup_script.bash](PreciousEddy/automated_database_backup_script.bash)
+- [backup_Script_with_timestamped-files.bash](PreciousEddy/backup_Script_with_timestamped-files.bash)
+- [file_backup_script.bash](PreciousEddy/file_backup_script.bash)
+- [user_account_management_script.bash](PreciousEddy/user_account_management_script.bash)
 
 ### Perl
 


### PR DESCRIPTION
I changed all of the links to script files from absolute paths to relative paths. There is no need to use the absolute path. You only need to specify the path relative to the root of the project in the Markdown files in the root.

This is already enough:
```
- [some_thing.sh](username/something.sh)
```

It's also better than using an absolute URL as the links will reflect the changes from the current branch they're on.