### PR TITLE
script for simple fzf based file manager in terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ To contribute, follow the guidelines in [CONTRIBUTING.md](CONTRIBUTING.md).
 - [Process_Check_Script.bash](PreciousEddy/Process_Check_Script.bash)
 - [remove_branches.bash](jsnoob921/remove_branches.bash)
 - [remove_stale_git_branches.sh](Sylphritz/remove_stale_git_branches.sh)
+- [simple_fzf_file_manager.bash](tusuii/simple_file_manager.bash)
 - [test_bash.bash](raymelon/test_bash.bash)
 - [user_account_management_script.bash](PreciousEddy/user_account_management_script.bash)
-- [simple_fzf_file_manager.bash](tusuii/simple_file_manager.bash)
 
 ### Perl 🐪
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ To contribute, follow the guidelines in [CONTRIBUTING.md](CONTRIBUTING.md).
 - [remove_stale_git_branches.sh](Sylphritz/remove_stale_git_branches.sh)
 - [test_bash.bash](raymelon/test_bash.bash)
 - [user_account_management_script.bash](PreciousEddy/user_account_management_script.bash)
+- [simple_fzf_file_manager.bash](tusuii/simple_file_manager.bash)
 
 ### Perl 🐪
 

--- a/tusuii/simple_file_manager.bash
+++ b/tusuii/simple_file_manager.bash
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+dir=$(pwd)
+files=($(find "$dir" -maxdepth 1 -type f -printf "%f\n" | sort))
+file_sel=$(printf "%s\n" "${files[@]}" | fzf --preview "file {}" --preview-window=up:30%:wrap)
+
+if [ -n "$file_sel" ]; then
+  ext="${file_sel##*.}"
+
+  case "$ext" in
+    "pdf")
+      zathura "$dir/$file_sel" &
+      ;;
+      
+    "jpg" | "jpeg" | "png" | "gif")
+
+      sxiv "$dir/$file_sel" &
+      ;;
+      
+    "xlsx" | "csv" | "ods")
+    
+    	libreoffice --calc "$dir/$file_sel" &
+    	;;
+    
+    "docx" | "odt")
+    
+    	libreoffice --writer "$dir/$file_sel" &
+    	;;
+    	
+    *)
+      xdg-open "$dir/$file_sel" &
+      ;;
+  esac
+fi


### PR DESCRIPTION
fzf file manager script in bash

### features
1. window to show file information.
2. can open wide ranges of files.
   a. *zathura* to open pdf files.
   b. *sxiv* to open png / jpeg files
   c. *libreoffice* calc / writer to open docx and xlxs files
3. if any app is missing it will open default app set in your system using xdg-open

This is my hacktoberfest contribution, please approve my PR, Thank you :handshake: 

![screenshot-20231025-202848](https://github.com/raymelon/scripting-recipes/assets/39451041/11fc45de-2666-4a47-bd50-2bb240745e1a)
